### PR TITLE
Add a variable to allow shifting the column address an arbitrary amount

### DIFF
--- a/adafruit_st7565.py
+++ b/adafruit_st7565.py
@@ -52,6 +52,9 @@ class ST7565(framebuf.FrameBuffer):
     # LCD Page Order
     pagemap = (0, 1, 2, 3, 4, 5, 6, 7)
 
+    # LCD Start Bytes
+    start_bytes = 0
+
     CMD_DISPLAY_OFF = const(0xAE)
     CMD_DISPLAY_ON = const(0xAF)
     CMD_SET_DISP_START_LINE = const(0x40)
@@ -146,9 +149,9 @@ class ST7565(framebuf.FrameBuffer):
             # Set page
             self.write_cmd(self.CMD_SET_PAGE | self.pagemap[page])
             # Set lower bits of column
-            self.write_cmd(self.CMD_SET_COLUMN_LOWER | (0 & 0xF))
+            self.write_cmd(self.CMD_SET_COLUMN_LOWER | (self.start_bytes & 0xF))
             # Set upper bits of column
-            self.write_cmd(self.CMD_SET_COLUMN_UPPER | ((0 >> 4) & 0xF))
+            self.write_cmd(self.CMD_SET_COLUMN_UPPER | ((self.start_bytes >> 4) & 0xF))
 
             # Page start row
             row_start = page << 7


### PR DESCRIPTION
Found this lurking as a const in the [old C library](https://github.com/adafruit/ST7565-LCD/blob/d40d9d832be8a6ce26d6462e85de3dcf439942fc/ST7565/ST7565.cpp#L593) as (`ST7565_STARTBYTES`), and although the value presented there wasn't working for my display, I was able to get my display working correctly with a different value. Decided to make it an instance variable so it can be adjusted as needed (alongside the pagemap list, which I also needed to adjust for my display).